### PR TITLE
Fix domain scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ src/assets/css
 src/index.html
 .DS_Store
 src/data*.json
+venv

--- a/scripts/alb-domains.py
+++ b/scripts/alb-domains.py
@@ -22,7 +22,7 @@ def show_cert_cn(cert, upload_cutoff):
         full_cert = iam.get_server_certificate(ServerCertificateName=cert['ServerCertificateName'])
         cert_body=full_cert['ServerCertificate']['CertificateBody']
         x509_cert = x509.load_pem_x509_certificate(cert_body.encode('utf-8'))
-        if x509_cert.not_valid_after > datetime.datetime.now():
+        if x509_cert.not_valid_after_utc > datetime.datetime.now(datetime.timezone.utc):
             domain_name = re.match(rf'<Name\(CN=(.*)\)\>', str(x509_cert.subject))
             if domain_name:
                 return domain_name.group(1)
@@ -34,7 +34,7 @@ if not os.environ.get('AWS_REGION')=='us-gov-west-1':
 iam = boto3.client('iam')
 paginator = iam.get_paginator('list_server_certificates')
 
-# Iterate over all the production ALB paths, get their certs, and pull out the 
+# Iterate over all the production ALB paths, get their certs, and pull out the
 # currently valid domains
 alb_domains = []
 ninety_days_ago = datetime.datetime.now() - datetime.timedelta(days=91)

--- a/scripts/cdn-domains.py
+++ b/scripts/cdn-domains.py
@@ -14,8 +14,17 @@ if not os.environ.get('AWS_REGION')=='us-east-1':
 cdn_domains = []
 cdn = boto3.client('cloudfront')
 cdn_response = cdn.list_distributions()
-for i in cdn_response['DistributionList']['Items']:
-        aliases = i['Aliases']['Items']
-        cdn_domains = cdn_domains + aliases
+
+hasMoreResults = True
+while hasMoreResults:
+    for i in cdn_response['DistributionList']['Items']:
+        if 'Items' in i['Aliases']:
+            aliases = i['Aliases']['Items']
+            cdn_domains = cdn_domains + aliases
+    hasMoreResults = cdn_response['DistributionList']['IsTruncated']
+    if hasMoreResults:
+        cdn_response = cdn.list_distributions(
+            Marker=cdn_response['DistributionList']['NextMarker']
+        )
 
 print(json.dumps(cdn_domains))


### PR DESCRIPTION
## Changes proposed in this pull request:

- [ignore virtualenv](https://github.com/cloud-gov/metrics-dashboard/commit/c0627ae39b444c3224cf2ca0c762736c89aeed98)
- [fix CDN domains script to iterate through all customer domains](https://github.com/cloud-gov/metrics-dashboard/commit/64886db9b830526f9d80ad1015c3931d1c21691b)
- [fix ALB domains script to address warnings](https://github.com/cloud-gov/metrics-dashboard/commit/0bc4ad1bfc51d71a39cd71d20bae1034a5c4726a)

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing script errors
