### PR TITLE
fix scripts to reference data folder for data.json

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-* @cloud-gov/customer-success-squad 
+* @cloud-gov/cloud-gov-team
 

--- a/ci/generate-html.sh
+++ b/ci/generate-html.sh
@@ -5,9 +5,9 @@ echo "==> Installing dependencies (deterministic)"
 npm ci
 
 echo "==> Preparing data.json"
-# Data is produced by the previous Concourse task into ../data
+# Data is produced by the previous Concourse task into data
 # Keep this explicit for now; we’ll clean the output path next.
-cp ../data/data.json src/data.json
+cp data/data.json src/data.json
 
 echo "==> Building dashboard (CSS + HTML)"
 npm run build

--- a/scripts/generate-data.sh
+++ b/scripts/generate-data.sh
@@ -37,4 +37,4 @@ jq -n -r \
   --argjson total_redis_instances "$TOTAL_REDIS_INSTANCES" \
   --argjson total_s3_instances "$TOTAL_S3_INSTANCES" \
   --argjson agencies_with_agreement "$agencies_with_agreement" \
-  '$ARGS.named' > "$SCRIPT_DIR/../src/data.json"
+  '$ARGS.named' > "$SCRIPT_DIR/../data/data.json"


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix scripts to reference data folder for data.json

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing build failures
