### PR TITLE
fix path when copying data file to generate HTML

### DIFF
--- a/ci/generate-html.sh
+++ b/ci/generate-html.sh
@@ -7,7 +7,7 @@ npm ci
 echo "==> Preparing data.json"
 # Data is produced by the previous Concourse task into data
 # Keep this explicit for now; we’ll clean the output path next.
-cp data/data.json src/data.json
+cp ../data/data.json src/data.json
 
 echo "==> Building dashboard (CSS + HTML)"
 npm run build


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix path when copying data file to generate HTML

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing build failures
