### PR TITLE
fix CI configuration for generate-data task 

### DIFF
--- a/ci/generate-data.yml
+++ b/ci/generate-data.yml
@@ -19,4 +19,5 @@ outputs:
 
 run:
   dir: src
-  path: scripts/generate-data.sh ../data/data.json
+  path: scripts/generate-data.sh
+  args: ../data/data.json


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix CI configuration for generate-data task to pass in arg for output file correctly
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing error
