### PR TITLE
fix YAML structure of args to generate-data CI task

### DIFF
--- a/ci/generate-data.yml
+++ b/ci/generate-data.yml
@@ -20,4 +20,5 @@ outputs:
 run:
   dir: src
   path: scripts/generate-data.sh
-  args: ../data/data.json
+  args:
+    - ../data/data.json


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix YAML structure of args to generate-data CI task

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None. Fixing build failures
