### PR TITLE
update dashboard customer metrics

### DIFF
--- a/scripts/generate-data.sh
+++ b/scripts/generate-data.sh
@@ -24,7 +24,7 @@ TOTAL_ES_INSTANCES=$("$SCRIPT_DIR"/get-service-offering-instance-count.sh aws-el
 TOTAL_REDIS_INSTANCES=$("$SCRIPT_DIR"/get-service-offering-instance-count.sh aws-elasticache-redis)
 # Platform and Pages S3 service instances
 TOTAL_S3_INSTANCES=$("$SCRIPT_DIR"/get-service-offering-instance-count.sh s3,federalist-s3)
-agencies_with_agreement=$("$SCRIPT_DIR"/get-agency-customers-count.sh)
+total_customer_orgs=$("$SCRIPT_DIR"/get-agency-customers-count.sh)
 
 OUTPUT_DATA_FILE="$1"
 if [[ -z $OUTPUT_DATA_FILE ]]; then
@@ -42,6 +42,6 @@ jq -n -r \
   --argjson total_es_instances "$TOTAL_ES_INSTANCES" \
   --argjson total_redis_instances "$TOTAL_REDIS_INSTANCES" \
   --argjson total_s3_instances "$TOTAL_S3_INSTANCES" \
-  --argjson agencies_with_agreement "$agencies_with_agreement" \
+  --argjson total_customer_orgs "$total_customer_orgs" \
   --argjson ses_emails_sent "$SES_EMAILS_SENT" \
   '$ARGS.named' > "$OUTPUT_DATA_FILE"

--- a/scripts/get-agency-customers-count.sh
+++ b/scripts/get-agency-customers-count.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 
-cf orgs \
-  | tail -n +4 \
-  | grep -v 'sandbox\|arsalan-haider\|mark-boyd\|3pao\|test-\|system\|david-anderson\|cf\|cloud-gov\|tech-talk' \
-  | cut -d - -f 1 \
-  | sort \
-  | uniq -c \
-  | wc -l \
-  | jq -r
+CUSTOMER_ORG_FILTER=$(echo "org-type=customer" | jq -Rr @uri)
+
+# NOTE: does not handle paging
+cf curl "/v3/organizations?per_page=5000&label_selector=$CUSTOMER_ORG_FILTER" | jq -r '.resources[].name' | sort | uniq | wc -l

--- a/src/generate-html.js
+++ b/src/generate-html.js
@@ -71,7 +71,7 @@ function main() {
   // Mustache renders missing keys as empty strings; that can hide data issues.
   // We do a small sanity check on expected keys to catch broken pipelines early.
   const requiredKeys = [
-    "agencies_with_agreement",
+    "total_customer_orgs",
     "total_sandbox_orgs",
     "total_domain_instances",
     "total_apps",
@@ -86,7 +86,7 @@ function main() {
   if (missing.length > 0) {
     throw new Error(
       `data.json is missing required keys:\n- ${missing.join("\n- ")}\n\n` +
-        "This usually means the data generation step failed or wrote unexpected output."
+      "This usually means the data generation step failed or wrote unexpected output."
     );
   }
 

--- a/src/index.html.mustache
+++ b/src/index.html.mustache
@@ -164,12 +164,12 @@
                 <div class="usa-card__container">
                   <header class="usa-card__header">
                     <p class="cg-metric__label margin-0">
-                      Agencies with an agreement
+                      Customer organizations
                     </p>
                   </header>
                   <div class="usa-card__body">
                     <p class="cg-metric__value margin-0">
-                      {{ agencies_with_agreement }}
+                      {{ total_customer_orgs }}
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
## Changes proposed in this pull request:

- update dashboard to show count of customer organizations, not agencies, since getting a count of agencies is unreliable

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
